### PR TITLE
アートワークをTemporaryItemsに書き込んでそのパスを返すようにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itunes-nowplaying-mac",
-  "version": "0.1.0",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "npm run build",
-    "build": "npm run ts-build && npm run as-build",
-    "ts-build": "tsc",
-    "as-build": "osacompile -o dist/itunes.scpt src/itunes.applescript"
+    "build": "npm run build:ts && npm run build:as",
+    "build:ts": "tsc",
+    "build:as": "osacompile -o dist/itunes.scpt src/itunes.applescript"
   },
   "typings": "dist/index.d.ts",
   "os": ["darwin"],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublish": "npm run build",
-    "build": "tsc"
+    "build": "npm run ts-build && npm run as-build",
+    "ts-build": "tsc",
+    "as-build": "osacompile -o dist/itunes.scpt src/itunes.applescript"
   },
   "typings": "dist/index.d.ts",
   "os": ["darwin"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itunes-nowplaying-mac",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ async function getData() {
         loved: res.loved as boolean,
         disliked: res.disliked as boolean,
         state: res.state as "playing" | "paused",
+        artwork: res.artworks[0] as {[key: string]: any} | null,
     }
 }
 

--- a/src/itunes.applescript
+++ b/src/itunes.applescript
@@ -1,0 +1,48 @@
+use scripting additions
+
+on run
+    tell application "iTunes"
+        try
+            set currentTrack to current track
+        on error errMsg number errNum
+            return
+        end try
+        set trackArtworks to []
+        repeat with trackArtwork in currentTrack's artworks
+            set imageData to trackArtwork's data
+            set imageFormat to trackArtwork's format
+            set imagePath to my tempFilePath(currentTrack's album, imageData, trackArtwork's format)
+            if imageFormat = JPEG picture then
+                set formatText to "JPEG"
+            else
+                set formatText to "PNG"
+            end if
+            if not (imagePath = (missing value)) then
+                set trackArtworks to trackArtworks & [{|path|:imagePath, |description|:trackArtwork's description, |downloaded|:trackArtwork's downloaded, |format|:formatText, |kind|:trackArtwork's kind}]
+            end if
+        end repeat
+    end tell
+    return trackArtworks
+end run
+
+on tempFilePath(albumName, imageData, imageFormat)
+    set extention to ".png"
+    if imageFormat = JPEG picture then
+        set extention to ".jpg"
+    end if
+    try
+        set a to (path to temporary items as text) & albumName & extention
+        set targetFile to POSIX path of a
+        set fh to open for access targetFile with write permission
+        write imageData to fh
+        close access fh
+        return targetFile
+    on error errMsg number errNum
+        try
+            close access fh
+        end try
+        log {errNum, errMsg}
+        return (missing value)
+    end try
+end tempFilePath
+

--- a/src/itunes.applescript
+++ b/src/itunes.applescript
@@ -9,7 +9,7 @@ on run
         end try
         set trackArtworks to []
         repeat with trackArtwork in currentTrack's artworks
-            set imageData to trackArtwork's data
+            set imageData to trackArtwork's raw data
             set imageFormat to trackArtwork's format
             set imagePath to my tempFilePath(currentTrack's album, imageData, trackArtwork's format)
             if imageFormat = JPEG picture then

--- a/src/itunes.js
+++ b/src/itunes.js
@@ -18,7 +18,7 @@ function run(argv) {
     })
     track.state = state
     track.artworks = []
-    if (currentTrack.existArtworks) {
+    if (currentTrack.artworks.length > 0) {
         track.artworks = app.runScript(Path(containerPath +"/itunes.scpt"))
     }
     return JSON.stringify(track, null, 4)

--- a/src/itunes.js
+++ b/src/itunes.js
@@ -1,16 +1,25 @@
-var itunes = Application("iTunes")
-var track = itunes.currentTrack
+var app = Application.currentApplication()
+app.includeStandardAdditions = true
+var pathToMe = app.pathTo(this)
+  , containerPath = Application('System Events').files[pathToMe.toString()].container().posixPath()
+  , itunes = Application('iTunes')
+  , currentTrack = itunes.currentTrack
+
 function run(argv) {
     var state = itunes.playerState()
     if (state != "playing" && state != "paused") {
         return "null"
     }
-    track = track.properties()
+    var track = currentTrack.properties()
     Object.keys(track).filter(function (name) {
         if (name.startsWith("purchase") || name.endsWith("ID")) {
             track[name] = undefined
         }
     })
     track.state = state
+    track.artworks = []
+    if (currentTrack.existArtworks) {
+        track.artworks = app.runScript(Path(containerPath +"/itunes.scpt"))
+    }
     return JSON.stringify(track, null, 4)
 }


### PR DESCRIPTION
JavaScriptでは`data`をうまく扱えないのでAppleScriptを追加しています
`properties of track`で取得できる`file track`クラスをAppleScriptでJSONにするのは難しいので変更前のままJavaScriptに任しています
`dist/`にはコンパイルしたバイナリを置く形になります