### PR TITLE
Get artworks base64

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "npm run build",
-    "build": "tsc"
+    "build": "tsc && cp src/itunes.js dist/itunes.js"
   },
   "typings": "dist/index.d.ts",
   "os": ["darwin"],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "npm run build",
-    "build": "tsc && cp src/itunes.js dist/itunes.js"
+    "build": "npm run build:ts && npm run build:as",
+    "build:ts": "tsc",
+    "build:as": "osacompile -o dist/itunes.scpt src/itunes.applescript && cp src/itunes.js dist/itunes.js"
   },
   "typings": "dist/index.d.ts",
   "os": ["darwin"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export async function getRawData(opts: JXAOpts = {}) {
         "-without-artworks"
     ] : []
     try {
-        const { stdout } = await promisifyExecFile(join(__dirname, "itunes.js"), cmdArgs);
+        const { stdout } = await promisifyExecFile(join(__dirname, "itunes.js"), cmdArgs, {maxBuffer:10*1024*1024});
         let res = JSON.parse(stdout.toString())
         return res as {[key: string]: any} | null;
     } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,18 @@
 import * as child_process from "child_process"
 import * as path from "path"
 
-export async function getRawData() {
+interface JXAOpts {
+    withoutArtworks?: boolean;
+}
+export async function getRawData(opts: JXAOpts = {}) {
     const raw_res = await new Promise<string>((resolve, reject) => {
         var stdout = ""
         var stderr = ""
-        var process = child_process.spawn("osascript", [path.join(__dirname, "itunes.js")])
+        var cmdParams = [path.join(__dirname, "itunes.js")]
+        if (opts.withoutArtworks) {
+            cmdParams.push("-without-artworks")
+        }
+        var process = child_process.spawn("osascript", cmdParams)
         process.stdout.on("data", (data) => {
             if (data instanceof Buffer) {
                 data = data.toString("utf-8")

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { execFile } from "child_process"
 import { join } from "path"
 const promisifyExecFile = promisify(execFile)
 
-interface JXAOpts {
+export interface JXAOpts {
     withoutArtworks?: boolean;
 }
 export async function getRawData(opts: JXAOpts = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,16 @@
-import * as child_process from "child_process"
-import * as path from "path"
+import { promisify } from "util"
+import { execFile } from "child_process"
+import { join } from "path"
+const promisifyExecFile = promisify(execFile)
 
 export async function getRawData() {
-    const raw_res = await new Promise<string>((resolve, reject) => {
-        var stdout = ""
-        var stderr = ""
-        var process = child_process.spawn("osascript", [path.join(__dirname, "itunes.js")])
-        process.stdout.on("data", (data) => {
-            if (data instanceof Buffer) {
-                data = data.toString("utf-8")
-            }
-            stdout += data
-        })
-        process.stderr.on("data", (data) => {
-            if (data instanceof Buffer) {
-                data = data.toString("utf-8")
-            }
-            stderr += data
-        })
-        process.on("close", (code) => {
-            if (code != 0) {
-                reject(stderr)
-            } else {
-                resolve(stdout)
-            }
-        })
-    })
-    const res = JSON.parse(raw_res)
-    return res as {[key: string]: any} | null;
+    try {
+        const { stdout } = await promisifyExecFile(join(__dirname, "itunes.js"));
+        let res = JSON.parse(stdout.toString())
+        return res as {[key: string]: any} | null;
+    } catch (e) {
+        throw e
+    }
 }
 async function getData() {
     const res = await getRawData()

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export async function getRawData(opts: JXAOpts = {}) {
     return res as {[key: string]: any} | null;
 }
 async function getData() {
-    const res = await getRawData()
+    const res = await getRawData({withoutArtworks:true})
     if (res == null) {
         return null
     }
@@ -66,6 +66,7 @@ async function getData() {
         loved: res.loved as boolean,
         disliked: res.disliked as boolean,
         state: res.state as "playing" | "paused",
+        existsArtwork: res.existsArtwork as boolean,
     }
 }
 

--- a/src/itunes.applescript
+++ b/src/itunes.applescript
@@ -1,0 +1,50 @@
+use scripting additions
+
+on run
+    tell application "iTunes"
+        try
+            set currentTrack to current track
+        on error errMsg number errNum
+            return
+        end try
+        set trackArtworks to []
+        repeat with trackArtwork in currentTrack's artworks
+            set imageData to trackArtwork's raw data
+            set imageFormat to trackArtwork's format
+            set imageBase64 to my artworkData(currentTrack's album, imageData, trackArtwork's format)
+            if imageFormat = JPEG picture then
+                set formatText to "JPEG"
+            else
+                set formatText to "PNG"
+            end if
+            if not (imageBase64 = (missing value)) then
+                set trackArtworks to trackArtworks & [{|data|:imageBase64, |description|:trackArtwork's description, |downloaded|:trackArtwork's downloaded, |format|:formatText, |kind|:trackArtwork's kind}]
+            end if
+        end repeat
+    end tell
+    return trackArtworks
+end run
+
+on artworkData(albumName, imageData, imageFormat)
+    set extention to ".png"
+    if imageFormat = JPEG picture then
+        set extention to ".jpg"
+    end if
+    try
+        set a to (path to temporary items as text) & albumName & extention
+        set targetFile to POSIX path of a
+        set fh to open for access targetFile with write permission
+        write imageData to fh
+        close access fh
+    on error errMsg number errNum
+        try
+            close access fh
+        end try
+        log {errNum, errMsg}
+        return (missing value)
+    end try
+    set base64Str to do shell script "/usr/bin/base64 " & (quoted form of targetFile)
+    tell application "System Events" to delete alias targetFile
+    return base64Str
+end artworkData
+

--- a/src/itunes.js
+++ b/src/itunes.js
@@ -16,6 +16,11 @@ function run(argv) {
         }
     })
     track.state = state
+    track.existsArtwork = existsArtwork
+    if (argv.includes("-without-artworks")) {
+        return JSON.stringify(track, null, 4)
+    }
+
     if (existsArtwork) {
         track.artworks = app.runScript(Path(containerPath +"/itunes.scpt"))
     } else {

--- a/src/itunes.js
+++ b/src/itunes.js
@@ -1,3 +1,4 @@
+#!/usr/bin/osascript -l JavaScript
 var itunes = Application("iTunes")
 var track = itunes.currentTrack
 function run(argv) {

--- a/src/itunes.js
+++ b/src/itunes.js
@@ -1,3 +1,6 @@
+var app = Application.currentApplication()
+app.includeStandardAdditions = true
+var containerPath = Application('System Events').files[app.pathTo(this).toString()].container().posixPath()
 var itunes = Application("iTunes")
 var track = itunes.currentTrack
 function run(argv) {
@@ -5,6 +8,7 @@ function run(argv) {
     if (state != "playing" && state != "paused") {
         return "null"
     }
+    var existsArtwork = track.artworks.length > 0
     track = track.properties()
     Object.keys(track).filter(function (name) {
         if (name.startsWith("purchase") || name.endsWith("ID")) {
@@ -12,5 +16,10 @@ function run(argv) {
         }
     })
     track.state = state
+    if (existsArtwork) {
+        track.artworks = app.runScript(Path(containerPath +"/itunes.scpt"))
+    } else {
+        track.artworks = []
+    }
     return JSON.stringify(track, null, 4)
 }


### PR DESCRIPTION
アートワークのbase64エンコードを取得できるようにします

- この変更には #3 と #5 が含まれています
- #1 では`TemporaryItems`に書き込んだ後そのままにしていたので、再起動後ゴミ箱にRecovered filesとして残っていました。こちらではそれを発生しないようにするためにbase64エンコードを生成後、削除しています
参考: https://discussions.apple.com/thread/7945692
- `getRawData`に`withoutArtworks`オプションをつけてアートワークを取得しないようにすることが可能です
