### PR TITLE
Path resolve in asar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,16 @@
-import * as child_process from "child_process"
-import * as path from "path"
+import { promisify } from "util"
+import { execFile } from "child_process"
+import { join } from "path"
+const promisifyExecFile = promisify(execFile)
 
 export async function getRawData() {
-    const raw_res = await new Promise<string>((resolve, reject) => {
-        var stdout = ""
-        var stderr = ""
-        var process = child_process.spawn("osascript", [path.join(__dirname, "itunes.js")])
-        process.stdout.on("data", (data) => {
-            if (data instanceof Buffer) {
-                data = data.toString("utf-8")
-            }
-            stdout += data
-        })
-        process.stderr.on("data", (data) => {
-            if (data instanceof Buffer) {
-                data = data.toString("utf-8")
-            }
-            stderr += data
-        })
-        process.on("close", (code) => {
-            if (code != 0) {
-                reject(stderr)
-            } else {
-                resolve(stdout)
-            }
-        })
-    })
-    const res = JSON.parse(raw_res)
-    return res as {[key: string]: any} | null;
+    try {
+        const { stdout } = await promisifyExecFile(join(__dirname, "itunes.js"));
+        let res = JSON.parse(stdout.toString())
+        return res as {[key: string]: any} | null;
+    } catch (e) {
+        throw e
+    }
 }
 async function getData() {
     const res = await getRawData()

--- a/src/itunes.js
+++ b/src/itunes.js
@@ -1,3 +1,4 @@
+#!/usr/bin/osascript -l JavaScript
 var itunes = Application("iTunes")
 var track = itunes.currentTrack
 function run(argv) {


### PR DESCRIPTION
asarに圧縮した際に`child_process.spawn`ではパスを解決できないので、`itunes.js`に実行権限を与えて`child_process.execFile`で実行する形にします

`util.promisify`でpromise化した`execFile`を利用した`try...catch`にします